### PR TITLE
php-redis and php-imagick recipes

### DIFF
--- a/vagrant_webapp/recipes/php_imagick.rb
+++ b/vagrant_webapp/recipes/php_imagick.rb
@@ -1,0 +1,9 @@
+script "compile and enable imagick extension" do
+	interpreter "bash"
+	user "root"
+	code <<-EOH
+	yum install -y gcc make wget tar ImageMagick ImageMagick-devel
+	echo | pecl install imagick
+	echo "extension=imagick.so" | tee /etc/php.d/imagick.ini
+	EOH
+end

--- a/vagrant_webapp/recipes/php_redis.rb
+++ b/vagrant_webapp/recipes/php_redis.rb
@@ -1,0 +1,9 @@
+script "compile and enable redis extension" do
+	interpreter "bash"
+	user "root"
+	code <<-EOH
+	yum install -y gcc make
+	echo | pecl install redis
+	echo "extension=redis.so" | tee /etc/php.d/redis.ini
+	EOH
+end


### PR DESCRIPTION
Add recipes to compile/install php-redis and php-imagick extensions. These are not available via yum for php8.x on Amazon Linux 2.

| extension | php8.0 | php8.1
|-----|-----|-----
| php-redis | no | no
| php-imagick | yes | no